### PR TITLE
Prevent cursor flicker on ImGui menu exit

### DIFF
--- a/dll/src/hooks/d3d12hook.cpp
+++ b/dll/src/hooks/d3d12hook.cpp
@@ -146,7 +146,7 @@ void InitImGui()
     ImGui::CreateContext();
     ImGuiIO &io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
-
+    io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;  // prevent system cursor flicker on exit
     ImGui::StyleColorsLight();
 
     ImGui_ImplWin32_Init(window);


### PR DESCRIPTION
Fixed it in the game ABYSSUS for me. Although my fork has many more changes to the hook, so it's possible that this alone won't fix it for all games.